### PR TITLE
Harris.kirk/switch set target cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following environment variables are required:
 
   This will be the root password to the linode VM instance, this is requried to be set when creating an instance.
 
-## Commands example
+## Command examples
 
 * ```$ make build```
 * ```$ make build_deploy```
@@ -46,7 +46,10 @@ The following environment variables are required:
 * ```$ bgdctl deploy dev```
 * ```$ bgdctl switch create dev```
 * ```$ bgdctl switch delete dev```
-
+* ```$ bgdctl switch-set-ip-target-to-cluster dev blue```
+* ```$ bgdctl switch-set-ip-target-to-cluster dev green```
+* ```$ bgdctl switch-set-ip-target-to-cluster prod blue```
+* ```$ bgdctl switch-set-ip-target-to-cluster prod green```
 
 
 

--- a/gwa-deploy/bgdctl
+++ b/gwa-deploy/bgdctl
@@ -216,8 +216,7 @@ def delete_environment(env: str):
     switch_resp = switch_module.switch_get(env)
     if switch_resp != []:
         switch_id = switch_resp[0]["id"]
-        logging.info(f"switch ID in environment {env} found: {switch_id}") 
-        switch_module.switch_delete(env)
+        logging.warning(f"switch ID in environment {env} found (no action taked): {switch_id}") 
 
 #\
 # All cli commands follow:

--- a/gwa-deploy/bgdctl
+++ b/gwa-deploy/bgdctl
@@ -306,5 +306,12 @@ def switch(operation: str, env: str, log_level = "debug"):
         case _:
             raise Exception("invalid switch command")
 
+@app.command()
+def switch_set_ip_target_to_cluster(env: str, target_env: str):
+    switch_module.switch_set_ip_target_to_cluster(env, target_env)
+
+    logging.info(f"nginx switch (env: {env}) succesfully set to target ({target_env})")
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
This PR is the essence of https://github.com/HarrisKirk/blue-green-dreams/pull/106 

I tested it by 
```
bgdctl deploy blueapple --keep
bgdctl switch-set-ip-target-to-cluster prodharris blueapple
bgdctl rm prodharris
# Note that I removed the code that deleted the switch since we obviously want the switch
# I then inspected the website to be sure it is still functional with the current time as proof
```
There is much refactoring to do but the test is a SUCCESS
